### PR TITLE
물건 교환 요청 생성 API 개발

### DIFF
--- a/src/main/java/kr/anabada/anabadaserver/common/controller/ImageUploadController.java
+++ b/src/main/java/kr/anabada/anabadaserver/common/controller/ImageUploadController.java
@@ -32,7 +32,7 @@ public class ImageUploadController {
     public GlobalResponse<List<String>> uploadImage(@CurrentUser User user,
                                                     @Schema(description = "업로드할 이미지 파일들", requiredMode = REQUIRED)
                                                     MultipartFile[] uploadFile,
-                                                    @RequestParam @Schema(description = "이미지 타입", example = "BUY_TOGETHER, KNOW_TOGETHER ....")
+                                                    @RequestParam @Schema(description = "이미지 타입", example = "BUY_TOGETHER, KNOW_TOGETHER, MY_PRODUCT ....")
                                                     String type) {
         if (user == null) {
             throw new CustomException(ErrorCode.ONLY_ACCESS_USER);

--- a/src/main/java/kr/anabada/anabadaserver/domain/change/controller/ProductChangeController.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/change/controller/ProductChangeController.java
@@ -1,0 +1,31 @@
+package kr.anabada.anabadaserver.domain.change.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.anabada.anabadaserver.domain.change.service.ProductChangeService;
+import kr.anabada.anabadaserver.domain.user.entity.User;
+import kr.anabada.anabadaserver.global.auth.CurrentUser;
+import kr.anabada.anabadaserver.global.response.CustomException;
+import kr.anabada.anabadaserver.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/changing")
+@Tag(name = "바꿔쓰기", description = "바꿔쓰기 관련 API")
+public class ProductChangeController {
+
+    private final ProductChangeService productChangeService;
+
+    @PostMapping("/{targetProductId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createChangeRequest(@CurrentUser User user, @PathVariable Long targetProductId, List<Long> myProductIds) {
+        if (user == null)
+            throw new CustomException(ErrorCode.ONLY_ACCESS_USER);
+
+        productChangeService.changeRequest(user, targetProductId, myProductIds);
+    }
+}

--- a/src/main/java/kr/anabada/anabadaserver/domain/change/controller/ProductController.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/change/controller/ProductController.java
@@ -15,10 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,7 +26,7 @@ public class ProductController {
 
     @PostMapping("/my-product")
     @Operation(summary = "바꿔쓰기에 사용할 내 상품 등록")
-    public void createMyProduct(@CurrentUser User user, @Valid MyProductRequest request) {
+    public void createMyProduct(@CurrentUser User user, @RequestBody @Valid MyProductRequest request) {
         if (user == null)
             throw new CustomException(ErrorCode.ONLY_ACCESS_USER);
 

--- a/src/main/java/kr/anabada/anabadaserver/domain/change/controller/ProductController.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/change/controller/ProductController.java
@@ -10,6 +10,7 @@ import kr.anabada.anabadaserver.domain.user.entity.User;
 import kr.anabada.anabadaserver.global.auth.CurrentUser;
 import kr.anabada.anabadaserver.global.response.CustomException;
 import kr.anabada.anabadaserver.global.response.ErrorCode;
+import kr.anabada.anabadaserver.global.response.GlobalResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -37,23 +38,23 @@ public class ProductController {
 
     @GetMapping("/my-product")
     @Operation(summary = "내 상품 목록 조회")
-    public Page<MyProductResponse> getMyProduct(@CurrentUser User user, String searchWord, Pageable pageable) {
+    public GlobalResponse<Page<MyProductResponse>> getMyProduct(@CurrentUser User user, String searchWord, Pageable pageable) {
         if (user == null)
             throw new CustomException(ErrorCode.ONLY_ACCESS_USER);
 
         if (isInvalidSearchWord(searchWord))
             throw new CustomException(ErrorCode.SEARCH_WORD_LENGTH);
 
-        return myProductService.getMyProducts(user, searchWord, pageable);
+        return new GlobalResponse<>(myProductService.getMyProducts(user, searchWord, pageable));
     }
 
     @GetMapping("/product")
     @Operation(summary = "모든(내 상품 포함) 상품 목록 조회")
-    public Page<MyProductResponse> getAllProduct(String searchWord, Pageable pageable) {
+    public GlobalResponse<Page<MyProductResponse>> getAllProduct(String searchWord, Pageable pageable) {
         if (isInvalidSearchWord(searchWord))
             throw new CustomException(ErrorCode.SEARCH_WORD_LENGTH);
 
-        return myProductService.getProducts(searchWord, pageable);
+        return new GlobalResponse<>(myProductService.getProducts(searchWord, pageable));
     }
 
     private boolean isInvalidSearchWord(String searchWord) {

--- a/src/main/java/kr/anabada/anabadaserver/domain/change/dto/MyProductResponse.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/change/dto/MyProductResponse.java
@@ -5,7 +5,7 @@ import kr.anabada.anabadaserver.domain.user.dto.UserDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -29,6 +29,16 @@ public class MyProductResponse {
     @Schema(description = "상품 상태", example = "AVAILABLE")
     private ProductStatus status;
 
-    @Schema(description = "상품 대표 이미지", example = "6d4ca57f-71c6-4886-b464-6d2847b3ebb8")
-    private UUID image;
+    @Schema(description = "상품 이미지 파일 이름")
+    private List<String> images;
+
+    public MyProductResponse(Long id, UserDto owner, String name, String content, int originalPrice, ProductStatus status, List<String> images) {
+        this.id = id;
+        this.owner = owner;
+        this.name = name;
+        this.content = content;
+        this.originalPrice = originalPrice;
+        this.status = status;
+        this.images = images;
+    }
 }

--- a/src/main/java/kr/anabada/anabadaserver/domain/change/entity/MyProduct.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/change/entity/MyProduct.java
@@ -2,6 +2,7 @@ package kr.anabada.anabadaserver.domain.change.entity;
 
 import jakarta.persistence.*;
 import kr.anabada.anabadaserver.common.entity.Image;
+import kr.anabada.anabadaserver.domain.change.dto.MyProductResponse;
 import kr.anabada.anabadaserver.domain.change.dto.ProductStatus;
 import kr.anabada.anabadaserver.domain.change.dto.ProductStatusConverter;
 import kr.anabada.anabadaserver.domain.user.entity.User;
@@ -14,6 +15,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import java.util.List;
+import java.util.UUID;
 
 import static kr.anabada.anabadaserver.domain.change.dto.ProductStatus.AVAILABLE;
 
@@ -61,4 +63,17 @@ public class MyProduct {
     @Builder.Default
     @Column(name = "is_removed", nullable = false)
     private Boolean isRemoved = false;
+
+    public MyProductResponse toResponse() {
+        return new MyProductResponse(id, owner.toDto(), name, content, originalPrice, status,
+                images == null ? null :
+                        images.stream()
+                                .map(Image::getId)
+                                .map(UUID::toString)
+                                .toList());
+    }
+
+    public void updateStatus(ProductStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/kr/anabada/anabadaserver/domain/change/respository/ProductRepository.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/change/respository/ProductRepository.java
@@ -1,7 +1,17 @@
 package kr.anabada.anabadaserver.domain.change.respository;
 
+import jakarta.persistence.LockModeType;
+import kr.anabada.anabadaserver.domain.change.dto.ProductStatus;
 import kr.anabada.anabadaserver.domain.change.entity.MyProduct;
+import kr.anabada.anabadaserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.List;
 
 public interface ProductRepository extends JpaRepository<MyProduct, Long>, ProductRepositoryCustom {
+    List<MyProduct> findAllByOwner(User user);
+
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    List<MyProduct> findAllByOwnerAndStatus(User owner, ProductStatus productStatus);
 }

--- a/src/main/java/kr/anabada/anabadaserver/domain/change/respository/ProductRepositoryCustom.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/change/respository/ProductRepositoryCustom.java
@@ -1,11 +1,18 @@
 package kr.anabada.anabadaserver.domain.change.respository;
 
 import kr.anabada.anabadaserver.domain.change.dto.MyProductResponse;
+import kr.anabada.anabadaserver.domain.change.dto.ProductStatus;
 import kr.anabada.anabadaserver.domain.change.respository.ProductRepositoryImpl.SearchProductRecord;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ProductRepositoryCustom {
     Page<MyProductResponse> findUserProductList(SearchProductRecord searchProduct);
+
+    void createChangeRequest(Long targetId, List<Long> myProductIds);
+
+    void updateStatus(List<Long> productIds, ProductStatus status);
 }

--- a/src/main/java/kr/anabada/anabadaserver/domain/change/respository/ProductRepositoryImpl.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/change/respository/ProductRepositoryImpl.java
@@ -1,6 +1,5 @@
 package kr.anabada.anabadaserver.domain.change.respository;
 
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.QBean;
@@ -10,6 +9,8 @@ import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.anabada.anabadaserver.common.dto.DomainType;
 import kr.anabada.anabadaserver.domain.change.dto.MyProductResponse;
+import kr.anabada.anabadaserver.domain.change.dto.ProductStatus;
+import kr.anabada.anabadaserver.domain.change.entity.MyProduct;
 import kr.anabada.anabadaserver.domain.user.dto.UserDto;
 import kr.anabada.anabadaserver.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.util.StringUtils;
 
+import java.util.List;
 import java.util.UUID;
 
 import static kr.anabada.anabadaserver.common.entity.QImage.image;
@@ -31,8 +33,23 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
+    public void createChangeRequest(Long targetId, List<Long> myProductIds) {
+
+    }
+
+    @Override
+    public void updateStatus(List<Long> productIds, ProductStatus status) {
+        List<MyProduct> products = queryFactory
+                .selectFrom(myProduct)
+                .where(myProduct.id.in(productIds))
+                .fetch();
+
+        products.forEach(product -> product.updateStatus(status));
+    }
+
+ /*   @Override
     public Page<MyProductResponse> findUserProductList(SearchProductRecord searchProduct) {
-        var result = queryFactory
+        List<MyProductResponse> result = queryFactory
                 .select(Projections.fields(MyProductResponse.class,
                         myProduct.id,
                         myProduct.name,
@@ -40,9 +57,9 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         myProduct.originalPrice,
                         myProduct.status,
                         getOwner().as("owner"),
-                        ExpressionUtils.as(
-                                getMainImage(), "image")))
+                        GroupBy.list(image.id).as("images")))
                 .from(myProduct)
+                .leftJoin(myProduct.images)
                 .where(myProduct.status.eq(AVAILABLE)
                         .and(onlyActivatedUser())
                         .and(onlyUserProduct(searchProduct.user))
@@ -53,6 +70,26 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .fetch();
 
         return new PageImpl<>(result, searchProduct.pageable, result.size());
+    }*/
+
+    @Override
+    public Page<MyProductResponse> findUserProductList(SearchProductRecord searchProduct) {
+        List<MyProduct> result = queryFactory
+                .selectFrom(myProduct)
+                .leftJoin(myProduct.images)
+                .where(myProduct.status.eq(AVAILABLE)
+                        .and(onlyActivatedUser())
+                        .and(onlyUserProduct(searchProduct.user))
+                        .and(keywordSearch(searchProduct.keyword)))
+                .orderBy(myProduct.id.desc())
+                .offset(searchProduct.pageable.getOffset())
+                .limit(searchProduct.pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(
+                result.stream().map(MyProduct::toResponse).toList(),
+                searchProduct.pageable,
+                result.size());
     }
 
     private Predicate onlyUserProduct(User user) {

--- a/src/main/java/kr/anabada/anabadaserver/domain/change/service/ProductChangeService.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/change/service/ProductChangeService.java
@@ -1,0 +1,44 @@
+package kr.anabada.anabadaserver.domain.change.service;
+
+import kr.anabada.anabadaserver.domain.change.dto.ProductStatus;
+import kr.anabada.anabadaserver.domain.change.entity.MyProduct;
+import kr.anabada.anabadaserver.domain.change.respository.ProductRepository;
+import kr.anabada.anabadaserver.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductChangeService {
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public void changeRequest(User user, long targetProductId, List<Long> toChangeProductIds) {
+        if (toChangeProductIds == null || toChangeProductIds.isEmpty())
+            throw new IllegalArgumentException("교환 신청할 물건은 최소 1개 이상이어야 합니다.");
+
+        List<MyProduct> myProducts = productRepository.findAllByOwnerAndStatus(user, ProductStatus.AVAILABLE);
+
+        // check toChange products are available and in my products
+        for (Long toChangeProductId : toChangeProductIds) {
+            if (myProducts.stream().noneMatch(myProduct -> Objects.equals(myProduct.getId(), toChangeProductId)))
+                throw new IllegalArgumentException(String.format("%d는 변경 신청 가능한 물건이 아닙니다.", toChangeProductId));
+        }
+
+        // check target product is available
+        MyProduct targetProduct = productRepository.findById(targetProductId).orElseThrow(() -> new IllegalArgumentException("상대 물건이 존재하지 않습니다."));
+        if (targetProduct.getStatus() != ProductStatus.AVAILABLE)
+            throw new IllegalArgumentException(String.format("%d는 변경 신청 가능한 물건이 아닙니다.", targetProductId));
+
+        // update product status
+        productRepository.updateStatus(toChangeProductIds, ProductStatus.REQUESTING);
+
+        // create change request
+        productRepository.createChangeRequest(targetProductId, toChangeProductIds);
+    }
+}

--- a/src/test/java/kr/anabada/anabadaserver/domain/change/entity/MyProductTest.java
+++ b/src/test/java/kr/anabada/anabadaserver/domain/change/entity/MyProductTest.java
@@ -1,0 +1,84 @@
+package kr.anabada.anabadaserver.domain.change.entity;
+
+import kr.anabada.anabadaserver.common.entity.Image;
+import kr.anabada.anabadaserver.domain.change.dto.MyProductResponse;
+import kr.anabada.anabadaserver.domain.user.entity.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("MyProduct 엔티티 테스트")
+@ExtendWith(SpringExtension.class)
+class MyProductTest {
+
+    @Test
+    @DisplayName("MyProduct 엔티티를 MyProductResponse로 변환한다.")
+    void toResponse() {
+        // given
+        User user = User.builder().id(1L).build();
+
+        List<Image> images = List.of(
+                Image.builder().id(UUID.randomUUID()).build(),
+                Image.builder().id(UUID.randomUUID()).build()
+        );
+
+        MyProduct myProduct = MyProduct.builder()
+                .id(1L)
+                .owner(user)
+                .name("name")
+                .content("content")
+                .originalPrice(1000)
+                .images(images)
+                .build();
+
+        // when
+        MyProductResponse myProductResponse = myProduct.toResponse();
+
+        // then
+        assertAll(
+                () -> {
+                    Assertions.assertEquals(myProduct.getId(), myProductResponse.getId());
+                    Assertions.assertEquals(myProduct.getName(), myProductResponse.getName());
+                    Assertions.assertEquals(myProduct.getContent(), myProductResponse.getContent());
+                    Assertions.assertEquals(myProduct.getOriginalPrice(), myProductResponse.getOriginalPrice());
+                    Assertions.assertEquals(myProduct.getImages().size(), myProductResponse.getImages().size());
+                }
+        );
+    }
+
+    @Test
+    @DisplayName("상품 이미지가 NULL이여도 MyProduct 엔티티를 MyProductResponse로 변환한다.")
+    void testToResponse() {
+        // given
+        User user = User.builder().id(1L).build();
+        MyProduct myProduct = MyProduct.builder()
+                .id(1L)
+                .owner(user)
+                .name("name")
+                .content("content")
+                .originalPrice(1000)
+                .images(null)
+                .build();
+
+        // when
+        MyProductResponse myProductResponse = myProduct.toResponse();
+
+        // then
+        assertAll(
+                () -> {
+                    Assertions.assertEquals(myProduct.getId(), myProductResponse.getId());
+                    Assertions.assertEquals(myProduct.getName(), myProductResponse.getName());
+                    Assertions.assertEquals(myProduct.getContent(), myProductResponse.getContent());
+                    Assertions.assertEquals(myProduct.getOriginalPrice(), myProductResponse.getOriginalPrice());
+                    Assertions.assertNull(myProductResponse.getImages());
+                }
+        );
+    }
+}

--- a/src/test/java/kr/anabada/anabadaserver/domain/change/service/ProductChangeServiceTest.java
+++ b/src/test/java/kr/anabada/anabadaserver/domain/change/service/ProductChangeServiceTest.java
@@ -1,0 +1,223 @@
+package kr.anabada.anabadaserver.domain.change.service;
+
+import jakarta.persistence.EntityManager;
+import kr.anabada.anabadaserver.domain.change.dto.ProductStatus;
+import kr.anabada.anabadaserver.domain.change.entity.MyProduct;
+import kr.anabada.anabadaserver.domain.change.respository.ProductRepository;
+import kr.anabada.anabadaserver.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static kr.anabada.anabadaserver.domain.change.dto.ProductStatus.REQUESTING;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+@DisplayName("내 물건 교환 신청 서비스")
+class ProductChangeServiceTest {
+
+    @Autowired
+    ProductChangeService productChangeService;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    @Autowired
+    EntityManager em;
+
+    User craeteUser(String nickname) {
+        return User.builder()
+                .nickname(nickname)
+                .role("ROLE_USER")
+                .activated(true)
+                .email("%s@test.com".formatted(nickname))
+                .build();
+    }
+
+    MyProduct createProduct(User owner, String name, ProductStatus status) {
+        return MyProduct.builder()
+                .owner(owner)
+                .name(name)
+                .content("%s 입니다.".formatted(name))
+                .originalPrice(10000)
+                .images(null)
+                .status(status)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("createChangeRequest 메소드는")
+    class createChangeRequest {
+
+        @Test
+        @DisplayName("모든 인자값이 정상일때 교환 신청을 생성한다.")
+        void success() {
+            // given
+            User targetUser = craeteUser("target");
+            MyProduct targetProduct = createProduct(targetUser, "targetProduct", ProductStatus.AVAILABLE);
+            em.persist(targetUser);
+            productRepository.save(targetProduct);
+
+            User requester = craeteUser("requester");
+            MyProduct requesterProduct1 = createProduct(requester, "requesterProduct1", ProductStatus.AVAILABLE);
+            MyProduct requesterProduct2 = createProduct(requester, "requesterProduct2", ProductStatus.AVAILABLE);
+            em.persist(requester);
+            productRepository.saveAll(List.of(requesterProduct1, requesterProduct2));
+
+            // when & then
+            assertDoesNotThrow(() -> productChangeService.changeRequest(requester, targetProduct.getId(), List.of(requesterProduct1.getId(), requesterProduct2.getId())));
+            assertNotNull(requesterProduct1.getId());
+            assertNotNull(requesterProduct2.getId());
+        }
+
+        @Test
+        @DisplayName("변경 제안한 내 물건 중 하나라도 거래중인 물건이 있으면 교환 신청을 생성하지 않는다.")
+        void fail() {
+            // given
+            User targetUser = craeteUser("target");
+            MyProduct targetProduct = createProduct(targetUser, "targetProduct", ProductStatus.AVAILABLE);
+            em.persist(targetUser);
+            productRepository.save(targetProduct);
+
+            User requester = craeteUser("requester");
+            MyProduct requesterProduct1 = createProduct(requester, "requesterProduct1", ProductStatus.AVAILABLE);
+            MyProduct requesterProduct2 = createProduct(requester, "requesterProduct2", REQUESTING);
+            em.persist(requester);
+            productRepository.saveAll(List.of(requesterProduct1, requesterProduct2));
+
+            // when & then
+            assertThrows(IllegalArgumentException.class,
+                    () -> productChangeService.changeRequest(requester, targetProduct.getId(), List.of(requesterProduct1.getId(), requesterProduct2.getId())),
+                    "%d는 변경 신청 가능한 물건이 아닙니다.".formatted(requesterProduct2.getId()));
+        }
+
+        @Test
+        @DisplayName("상대 물건 상태가 교환완료(CHANGE)인 경우 교환 신청을 생성하지 않는다.")
+        void fail_target_product_already_changed() {
+            // given
+            User targetUser = craeteUser("target");
+            MyProduct targetProduct = createProduct(targetUser, "targetProduct", ProductStatus.CHANGED);
+            em.persist(targetUser);
+            productRepository.save(targetProduct);
+
+            User requester = craeteUser("requester");
+            MyProduct requesterProduct1 = createProduct(requester, "requesterProduct1", ProductStatus.AVAILABLE);
+            MyProduct requesterProduct2 = createProduct(requester, "requesterProduct2", ProductStatus.AVAILABLE);
+            em.persist(requester);
+            productRepository.saveAll(List.of(requesterProduct1, requesterProduct2));
+
+            // when & then
+            assertThrows(IllegalArgumentException.class,
+                    () -> productChangeService.changeRequest(requester, targetProduct.getId(), List.of(requesterProduct1.getId(), requesterProduct2.getId())),
+                    "%d는 변경 신청 가능한 물건이 아닙니다.".formatted(targetProduct.getId()));
+        }
+
+        @Test
+        @DisplayName("변경 신청이 생성되면, 내 물건 상태가 변경중(REQUESTING)으로 변경된다.")
+        void change_my_product_status_requesting_when_success() {
+            // given
+            User targetUser = craeteUser("target");
+            MyProduct targetProduct = createProduct(targetUser, "targetProduct", ProductStatus.AVAILABLE);
+            em.persist(targetUser);
+            productRepository.save(targetProduct);
+
+            User requester = craeteUser("requester");
+            MyProduct requesterProduct1 = createProduct(requester, "requesterProduct1", ProductStatus.AVAILABLE);
+            MyProduct requesterProduct2 = createProduct(requester, "requesterProduct2", ProductStatus.AVAILABLE);
+            em.persist(requester);
+            productRepository.saveAll(List.of(requesterProduct1, requesterProduct2));
+
+            // when
+            productChangeService.changeRequest(requester, targetProduct.getId(), List.of(requesterProduct1.getId(), requesterProduct2.getId()));
+
+            // then
+            assertEquals(REQUESTING, requesterProduct1.getStatus());
+            assertEquals(REQUESTING, requesterProduct2.getStatus());
+        }
+
+        @Test
+        @DisplayName("교환에 신청한 물건 인자값이 없으면(NULL) 교환 신청을 생성하지 않는다.")
+        void cant_input_myProduct_null() {
+            // given
+            User targetUser = craeteUser("target");
+            MyProduct targetProduct = createProduct(targetUser, "targetProduct", ProductStatus.AVAILABLE);
+            em.persist(targetUser);
+            productRepository.save(targetProduct);
+
+            User requester = craeteUser("requester");
+            em.persist(requester);
+
+            // when & then
+            assertThrows(IllegalArgumentException.class,
+                    () -> productChangeService.changeRequest(requester, targetProduct.getId(), null),
+                    "교환 신청할 물건은 최소 1개 이상이어야 합니다.");
+        }
+
+        @Test
+        @DisplayName("교환에 신청한 물건 인자값이 없으면(EMPTY) 교환 신청을 생성하지 않는다.")
+        void cant_input_myProduct_empty() {
+            // given
+            User targetUser = craeteUser("target");
+            MyProduct targetProduct = createProduct(targetUser, "targetProduct", ProductStatus.AVAILABLE);
+            em.persist(targetUser);
+            productRepository.save(targetProduct);
+
+            User requester = craeteUser("requester");
+            em.persist(requester);
+
+            // when & then
+            assertThrows(IllegalArgumentException.class,
+                    () -> productChangeService.changeRequest(requester, targetProduct.getId(), List.of()),
+                    "교환 신청할 물건은 최소 1개 이상이어야 합니다.");
+        }
+
+        @Test
+        @DisplayName("상대 물건이 삭제된 경우엔 교환 신청을 생성하지 않는다.")
+        void cant_create_about_removed_target_product() {
+            // given
+            User targetUser = craeteUser("target");
+            MyProduct targetProduct = createProduct(targetUser, "targetProduct", ProductStatus.AVAILABLE);
+            em.persist(targetUser);
+            productRepository.save(targetProduct);
+
+            User requester = craeteUser("requester");
+            MyProduct requesterProduct = createProduct(requester, "requesterProduct1", ProductStatus.AVAILABLE);
+            em.persist(requester);
+            productRepository.save(requesterProduct);
+
+            // when & then
+            em.remove(targetProduct);
+            assertThrows(IllegalArgumentException.class,
+                    () -> productChangeService.changeRequest(requester, targetProduct.getId(), List.of(requesterProduct.getId())),
+                    "상대 물건이 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("내 물건이 삭제된 경우엔 교환 신청을 생성하지 않는다.")
+        void cant_create_about_removed_my_product() {
+            // given
+            User targetUser = craeteUser("target");
+            MyProduct targetProduct = createProduct(targetUser, "targetProduct", ProductStatus.AVAILABLE);
+            em.persist(targetUser);
+            productRepository.save(targetProduct);
+
+            User requester = craeteUser("requester");
+            MyProduct requesterProduct1 = createProduct(requester, "requesterProduct1", ProductStatus.AVAILABLE);
+            MyProduct requesterProduct2 = createProduct(requester, "requesterProduct2", ProductStatus.AVAILABLE);
+            em.persist(requester);
+            productRepository.saveAll(List.of(requesterProduct1, requesterProduct2));
+
+            // when & then
+            em.remove(requesterProduct1);
+            assertThrows(IllegalArgumentException.class,
+                    () -> productChangeService.changeRequest(requester, targetProduct.getId(), List.of(requesterProduct1.getId())),
+                    "%d는 변경 신청 가능한 물건이 아닙니다.".formatted(requesterProduct1.getId()));
+        }
+    }
+}


### PR DESCRIPTION
물건 교환 요청 생성 개발
동시성에 대한 문제점(각 물건마다 STATUS 칼럼) 때문에 select for update를 해두긴했지만, 정상동작하는지 확인은 안해보았음.

## todo
- 동시성 문제 확인
- 물건 교환 요청 조회/승인 등
- Message 도메인은 changing끝나고 바로 해야될듯?