### PR TITLE
feat: 댓글 작성시 최대 depth를 2로 제한

### DIFF
--- a/src/main/java/kr/anabada/anabadaserver/common/controller/CommentController.java
+++ b/src/main/java/kr/anabada/anabadaserver/common/controller/CommentController.java
@@ -7,14 +7,18 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kr.anabada.anabadaserver.common.dto.CommentRequest;
+import kr.anabada.anabadaserver.common.dto.CommentResponse;
 import kr.anabada.anabadaserver.common.service.CommentService;
 import kr.anabada.anabadaserver.domain.user.entity.User;
 import kr.anabada.anabadaserver.global.auth.CurrentUser;
 import kr.anabada.anabadaserver.global.response.CustomException;
 import kr.anabada.anabadaserver.global.response.ErrorCode;
+import kr.anabada.anabadaserver.global.response.GlobalResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,19 +46,17 @@ public class CommentController {
         commentService.writeNewComment(user, postType, postId, commentRequest);
     }
 
-//    @GetMapping("/comment/{postType}/{postId}")
-//    @Operation(summary = "댓글 조회 API", description = "댓글을 조회합니다.")
-//    public GlobalResponse<CommentResponse> readComments(
-//            @Parameter(description = "댓글을 달 게시판 타입", required = true,
-//                    examples = {
-//                            @ExampleObject(name = "같이 사요", value = "buy-together"),
-//                            @ExampleObject(name = "같이 알아요", value = "know-together"),
-//                    })
-//            @NotNull(message = "조회 할 게시판 타입을 입력해주세요.")
-//            @PathVariable String postType,
-//            @NotNull(message = "조회 할 게시물 id를 입력해주세요") @PathVariable Long postId) {
-//        commentService.getPostComments(postType, postId);
-//
-//        return null;
-//    }
+    @GetMapping("/comment/{postType}/{postId}")
+    @Operation(summary = "댓글 조회 API", description = "댓글을 조회합니다.")
+    public GlobalResponse<List<CommentResponse>> readComments(
+            @Parameter(description = "댓글을 달 게시판 타입", required = true,
+                    examples = {
+                            @ExampleObject(name = "같이 사요", value = "buy-together"),
+                            @ExampleObject(name = "같이 알아요", value = "know-together"),
+                    })
+            @NotNull(message = "조회 할 게시판 타입을 입력해주세요.")
+            @PathVariable String postType,
+            @NotNull(message = "조회 할 게시물 id를 입력해주세요") @PathVariable Long postId) {
+        return new GlobalResponse<>(commentService.getPostComments(postType, postId));
+    }
 }

--- a/src/main/java/kr/anabada/anabadaserver/common/dto/CommentResponse.java
+++ b/src/main/java/kr/anabada/anabadaserver/common/dto/CommentResponse.java
@@ -1,0 +1,36 @@
+package kr.anabada.anabadaserver.common.dto;
+
+import kr.anabada.anabadaserver.domain.user.dto.UserDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CommentResponse {
+    private CommentItem parentComment;
+    private List<CommentItem> childComments = new ArrayList<>();
+
+    public CommentResponse(CommentItem parentComment, List<CommentItem> childComments) {
+        this.parentComment = parentComment;
+        this.childComments = childComments;
+    }
+
+    @Getter
+    @SuperBuilder
+    public static class CommentItem extends LocalDateResponse {
+        private final Long id;
+        private final UserDto writer;
+        private final String content;
+
+        public CommentItem(LocalDateResponseBuilder<?, ?> b, Long id, UserDto writer, String content) {
+            super(b);
+            this.id = id;
+            this.writer = writer;
+            this.content = content;
+        }
+    }
+}

--- a/src/main/java/kr/anabada/anabadaserver/common/entity/Comment.java
+++ b/src/main/java/kr/anabada/anabadaserver/common/entity/Comment.java
@@ -5,11 +5,16 @@ import kr.anabada.anabadaserver.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Where;
+
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @Table(name = "comment")
+@Where(clause = "is_removed = false")
 public class Comment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,20 +34,27 @@ public class Comment extends BaseTimeEntity {
     @Column(name = "content", nullable = false, length = 500)
     private String content;
 
-    @Column(name = "parent_comment_id")
-    private Long parentCommentId;
-
     @Column(name = "is_removed", nullable = false)
     private boolean isRemoved = false;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @OrderBy("id ASC")
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "parentComment", fetch = FetchType.LAZY)
+    private List<Comment> childComments;
+
     @Builder
-    public Comment(Long id, String postType, Long postId, User writer, String content, Long parentCommentId, boolean isRemoved) {
+    public Comment(Long id, String postType, Long postId, User writer, String content, boolean isRemoved, Comment parentComment, List<Comment> childComments) {
         this.id = id;
         this.postType = postType;
         this.postId = postId;
         this.writer = writer;
         this.content = content;
-        this.parentCommentId = parentCommentId;
         this.isRemoved = isRemoved;
+        this.parentComment = parentComment;
+        this.childComments = childComments;
     }
 }

--- a/src/main/java/kr/anabada/anabadaserver/common/repository/CommentRepository.java
+++ b/src/main/java/kr/anabada/anabadaserver/common/repository/CommentRepository.java
@@ -3,8 +3,5 @@ package kr.anabada.anabadaserver.common.repository;
 import kr.anabada.anabadaserver.common.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
-public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByPostTypeAndPostIdAndIsRemovedFalse(String postType, Long postId);
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 }

--- a/src/main/java/kr/anabada/anabadaserver/common/repository/CommentRepositoryCustom.java
+++ b/src/main/java/kr/anabada/anabadaserver/common/repository/CommentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package kr.anabada.anabadaserver.common.repository;
+
+import kr.anabada.anabadaserver.common.dto.CommentResponse;
+
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+    List<CommentResponse> getCommentsByPost(String postType, Long postId);
+}

--- a/src/main/java/kr/anabada/anabadaserver/common/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/kr/anabada/anabadaserver/common/repository/CommentRepositoryCustomImpl.java
@@ -1,0 +1,69 @@
+package kr.anabada.anabadaserver.common.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.anabada.anabadaserver.common.dto.CommentResponse;
+import kr.anabada.anabadaserver.common.entity.Comment;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static kr.anabada.anabadaserver.common.entity.QComment.comment;
+
+@RequiredArgsConstructor
+public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CommentResponse> getCommentsByPost(String postType, Long postId) {
+        List<Comment> result = queryFactory.selectFrom(comment)
+                .leftJoin(comment.childComments).fetchJoin()
+                .leftJoin(comment.writer).fetchJoin()
+                .where(checkPost(postType, postId)
+                        .and(isParentComment()))
+                .fetch();
+
+        return commentToResponse(result);
+    }
+
+    private BooleanExpression isParentComment() {
+        return comment.parentComment.isNull();
+    }
+
+    private BooleanExpression checkPost(String postType, Long postId) {
+        return comment.postType.eq(postType)
+                .and(comment.postId.eq(postId));
+    }
+
+    private List<CommentResponse> commentToResponse(List<Comment> result) {
+        List<CommentResponse> response = new ArrayList<>();
+        result.forEach(tuple -> {
+            CommentResponse.CommentItem parent = CommentResponse.CommentItem.builder()
+                    .id(tuple.getId())
+                    .writer(Objects.requireNonNull(tuple.getWriter()).toDto())
+                    .content(tuple.getContent())
+                    .createdAt(tuple.getCreatedAt())
+                    .modifiedAt(tuple.getModifiedAt())
+                    .build();
+
+            List<CommentResponse.CommentItem> child = new ArrayList<>();
+
+            if (tuple.getChildComments() != null) {
+                for (Comment c : tuple.getChildComments()) {
+                    child.add(CommentResponse.CommentItem.builder()
+                            .id(c.getId())
+                            .writer(Objects.requireNonNull(c.getWriter()).toDto())
+                            .content(c.getContent())
+                            .createdAt(c.getCreatedAt())
+                            .modifiedAt(c.getModifiedAt())
+                            .build());
+                }
+            }
+
+            response.add(new CommentResponse(parent, child));
+        });
+        return response;
+    }
+}

--- a/src/main/java/kr/anabada/anabadaserver/common/service/CommentService.java
+++ b/src/main/java/kr/anabada/anabadaserver/common/service/CommentService.java
@@ -59,12 +59,19 @@ public class CommentService {
     }
 
     private Comment returnIfChildComment(Long parentCommentId) {
+        // Check if parentCommentId is null
         if (parentCommentId == null) {
             return null;
         }
-
-        return commentRepository.findById(parentCommentId)
+        // Find the parent comment using parentCommentId
+        Comment parent = commentRepository.findById(parentCommentId)
                 .orElseThrow(() -> new IllegalArgumentException("부모 댓글이 존재하지 않습니다."));
+        // Check if the parent comment has a parent comment (depth is limited to 2 levels)
+        if (parent.getParentComment() != null) {
+            throw new IllegalArgumentException("댓글의 depth는 2단계까지만 가능합니다.");
+        }
+        // Return the parent comment
+        return parent;
     }
 
 

--- a/src/test/java/kr/anabada/anabadaserver/common/service/CommentServiceTest.java
+++ b/src/test/java/kr/anabada/anabadaserver/common/service/CommentServiceTest.java
@@ -40,7 +40,7 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
     @Nested
     @DisplayName("댓글을 조회할 때 - getPostComments()")
     class readComment {
-        
+
         @Test
         @DisplayName("대댓글도 함께 조회된다.")
         void read_comment_success() {
@@ -79,7 +79,6 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
                     .containsExactly(tuple("댓글작성자닉네임", "대댓글 내용"));
 
         }
-
     }
 
     @Nested
@@ -129,7 +128,6 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
                 commentService.writeNewComment(user, "buy-together", postId, commentRequest);
             });
         }
-
 
         @Test
         @DisplayName("댓글 내용이 없으면 IAE 예외가 발생한다.")

--- a/src/test/java/kr/anabada/anabadaserver/common/service/CommentServiceTest.java
+++ b/src/test/java/kr/anabada/anabadaserver/common/service/CommentServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import static kr.anabada.anabadaserver.fixture.dto.BuyTogetherFixture.createBuyTogetherParcel;
+import static kr.anabada.anabadaserver.fixture.entity.UserFixture.createUser;
 
 @Transactional
 @DisplayName("댓글 서비스에서 - CommentService")
@@ -48,7 +49,7 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
         @DisplayName("모든 인자값이 정상이라면 부모 댓글이 작성된다.")
         void success_parent_comment() {
             // given
-            User user = createUserA();
+            User user = createUser("user@naver.com", "1234");
             em.persist(user);
 
             BuyTogetherRequest post = createBuyTogetherParcel();
@@ -69,7 +70,7 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
         @DisplayName("모든 인자값이 정상이라면 대댓글이 작성된다.")
         void success_sub_comment() {
             // given
-            User user = createUserA();
+            User user = createUser("user@naver.com", "1234");
             em.persist(user);
 
             BuyTogetherRequest post = createBuyTogetherParcel();
@@ -93,7 +94,7 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
         @DisplayName("댓글 내용이 없으면 IAE 예외가 발생한다.")
         void comment_null_error() {
             // given
-            User user = createUserA();
+            User user = createUser("user@naver.com", "1234");
             em.persist(user);
 
             BuyTogetherRequest post = createBuyTogetherParcel();
@@ -114,7 +115,7 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
         @DisplayName("작성자가 없으면 DataIntegrityViolationException 예외가 발생한다.")
         void comment_writer_null_error() {
             // given
-            User user = createUserA();
+            User user = createUser("user@naver.com", "1234");
             em.persist(user);
 
             BuyTogetherRequest post = createBuyTogetherParcel();
@@ -135,7 +136,7 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
         @DisplayName("존재하지 않는 게시물 id(postId)에 댓글을 작성하면 IAE 예외가 발생한다.")
         void cant_comment_notExist_postId() {
             // given
-            User user = createUserA();
+            User user = createUser("user@naver.com", "1234");
             em.persist(user);
 
             CommentRequest commentRequest = CommentRequest.builder()
@@ -154,7 +155,7 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
         @DisplayName("존재하지 않는 게시판(post_type)에 댓글을 작성하면 IAE 예외가 발생한다.")
         void cant_comment_notExist_postType() {
             // given
-            User user = createUserA();
+            User user = createUser("user@naver.com", "1234");
             em.persist(user);
 
             BuyTogetherRequest post = createBuyTogetherParcel();
@@ -177,7 +178,7 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
         @DisplayName("댓글 내용이 길면(500자 초과) 작성할 수 없다.")
         void cant_comment_content_too_long() {
             // given
-            User user = createUserA();
+            User user = createUser("user@naver.com", "1234");
             em.persist(user);
 
             BuyTogetherRequest post = createBuyTogetherParcel();

--- a/src/test/java/kr/anabada/anabadaserver/common/service/CommentServiceTest.java
+++ b/src/test/java/kr/anabada/anabadaserver/common/service/CommentServiceTest.java
@@ -2,6 +2,7 @@ package kr.anabada.anabadaserver.common.service;
 
 import jakarta.persistence.EntityManager;
 import kr.anabada.anabadaserver.common.dto.CommentRequest;
+import kr.anabada.anabadaserver.common.dto.CommentResponse;
 import kr.anabada.anabadaserver.domain.ServiceTestWithoutImageUpload;
 import kr.anabada.anabadaserver.domain.save.dto.request.BuyTogetherRequest;
 import kr.anabada.anabadaserver.domain.save.service.BuyTogetherService;
@@ -16,8 +17,12 @@ import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static kr.anabada.anabadaserver.fixture.dto.BuyTogetherFixture.createBuyTogetherParcel;
 import static kr.anabada.anabadaserver.fixture.entity.UserFixture.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 @Transactional
 @DisplayName("댓글 서비스에서 - CommentService")
@@ -32,13 +37,49 @@ class CommentServiceTest extends ServiceTestWithoutImageUpload {
     @Autowired
     private EntityManager em;
 
-    private User createUserA() {
-        return User.builder()
-                .nickname("userA")
-                .email("userA@test.com")
-                .activated(true)
-                .role("ROLE_USER")
-                .build();
+    @Nested
+    @DisplayName("댓글을 조회할 때 - getPostComments()")
+    class readComment {
+        
+        @Test
+        @DisplayName("대댓글도 함께 조회된다.")
+        void read_comment_success() {
+            // given
+            User user = createUser("user@naver.com", "댓글작성자닉네임");
+            em.persist(user);
+
+            BuyTogetherRequest post = createBuyTogetherParcel();
+            long postId = buyTogetherService.createNewBuyTogetherPost(user, post).getId();
+
+            CommentRequest parentCommentRequest = CommentRequest.builder()
+                    .content("부모 댓글 내용")
+                    .parentCommentId(null)
+                    .build();
+            long parentCommentId = commentService.writeNewComment(user, "buy-together", postId, parentCommentRequest);
+
+            CommentRequest childCommentRequest = CommentRequest.builder()
+                    .content("대댓글 내용")
+                    .parentCommentId(parentCommentId)
+                    .build();
+
+            commentService.writeNewComment(user, "buy-together", postId, childCommentRequest);
+            //todo : em.clear()없이 대댓글이 정상적으로 조회되도록 수정 - 성훈
+            em.clear();
+
+            // when
+            List<CommentResponse> result = commentService.getPostComments("buy-together", postId);
+
+            // then
+            assertThat(result.get(0).getParentComment())
+                    .extracting("id", "content")
+                    .containsExactly(parentCommentId, "부모 댓글 내용");
+
+            assertThat(result.get(0).getChildComments())
+                    .extracting("writer.nickname", "content")
+                    .containsExactly(tuple("댓글작성자닉네임", "대댓글 내용"));
+
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
## 체크리스트

- [x] 구현한 기능에 대해서 서비스 레이어 통합 테스트코드를 작성했는가?
- [x] (컨트롤러단 테스트를 작성하지 않은 경우) 직접 HTTP 요청을 보내서 충분히 테스트를 진행했는가?
- [x] 모든(본인이 작성한 + 기존 테스트) 테스트 케이스를 통과했는가?

## 상세 내용

대댓글의 최대 depth를 제한하는 로직을 생성하고, 
테스트를 작성하였음.

<!--
- 구현한 기능에 대해서 자세히 설명
-->

## 관련 이슈 번호 및 링크

<!--
[#1 이슈 이름]()
-->