### PR TITLE
fix: '아껴쓰기 - 같이 사요' 게시물 생성시, 금액 정보 누락에 대한 대응

### DIFF
--- a/src/main/java/kr/anabada/anabadaserver/domain/save/dto/request/BuyTogetherRequest.java
+++ b/src/main/java/kr/anabada/anabadaserver/domain/save/dto/request/BuyTogetherRequest.java
@@ -82,6 +82,11 @@ public abstract class BuyTogetherRequest {
             throw new IllegalArgumentException("상품 구매처는 온라인 혹은 오프라인 중 하나여야 합니다.");
         }
 
+        // check pay is not null and positive
+        if (pay == null || pay <= 0) {
+            throw new IllegalArgumentException("상대가 지불해야 할 돈은 0 보다 커야합니다.");
+        }
+
 
         if (images == null || images.isEmpty()) {
             // 이미지를 업로드 하지 않았을때

--- a/src/test/java/kr/anabada/anabadaserver/domain/save/service/BuyTogetherServiceTest.java
+++ b/src/test/java/kr/anabada/anabadaserver/domain/save/service/BuyTogetherServiceTest.java
@@ -256,5 +256,37 @@ class BuyTogetherServiceTest extends ServiceTestWithoutImageUpload {
                 buyTogetherService.getPost(post.getId());
             }, "해당 게시물이 없습니다.");
         }
+
+        @Test
+        @DisplayName("금액 정보가 없으면 작성에 실패한다.")
+        void fail_when_pay_is_null() {
+            // given
+            User user = createUser("test@test.com", "test");
+            em.persist(user);
+
+            BuyTogetherRequest request = createBuyTogetherMeet(true);
+            ReflectionTestUtils.setField(request, "pay", null);
+
+            // when & then
+            Assertions.assertThrows(IllegalArgumentException.class, () -> {
+                buyTogetherService.createNewBuyTogetherPost(user, request);
+            }, "상대가 지불해야 할 돈은 0 보다 커야합니다.");
+        }
+
+        @Test
+        @DisplayName("금액 정보가 음수값이면 작성에 실패한다.")
+        void fail_when_pay_is_negative() {
+            // given
+            User user = createUser("test@test.com", "test");
+            em.persist(user);
+
+            BuyTogetherRequest request = createBuyTogetherMeet(true);
+            ReflectionTestUtils.setField(request, "pay", -10);
+
+            // when & then
+            Assertions.assertThrows(IllegalArgumentException.class, () -> {
+                buyTogetherService.createNewBuyTogetherPost(user, request);
+            }, "상대가 지불해야 할 돈은 0 보다 커야합니다.");
+        }
     }
 }


### PR DESCRIPTION
## 체크리스트

- [x] 구현한 기능에 대해서 서비스 레이어 통합 테스트코드를 작성했는가?
- [x] (컨트롤러단 테스트를 작성하지 않은 경우) 직접 HTTP 요청을 보내서 충분히 테스트를 진행했는가?
- [x] 모든(본인이 작성한 + 기존 테스트) 테스트 케이스를 통과했는가?

## 요약

<img width="488" alt="image" src="https://github.com/a-na-ba-da/backend/assets/13290706/95610f08-aead-45ce-aee5-6b8c72d4565b">

아껴쓰기 - 같이사요에서,
게시물을 생성할때,
금액정보가 누락이 되어도 게시물이 생성되던 오류를 해결 하였음.

## 관련 이슈 번호 및 링크

<!--
[#1 이슈 이름]()
-->